### PR TITLE
Adding fix in dealloc to remove text field observer.

### DIFF
--- a/RMSTokenView/RMSTokenView.m
+++ b/RMSTokenView/RMSTokenView.m
@@ -113,6 +113,11 @@ NSString *RMSBackspaceUnicodeString = @"\u200B";
     [self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(viewSelected:)]];
 }
 
+- (void)dealloc {
+    self.textField.delegate = nil;
+    [self.textField removeObserver:self forKeyPath:@"selectedTextRange" context:RMSTokenSelectionContext];
+}
+
 #pragma mark - Actions
 
 - (void)addTokenWithText:(NSString *)tokenText {


### PR DESCRIPTION
The `UITextField` instance kept by `RMSTokenView` complained during `-[RMSTokenView dealloc]` because its observer was still attached while it was deallocated. The warning I was receiving (`0x9152760` being `self.textField`, and `0xc959c00` being its parent instance of `RMSTokenView`):

```
An instance 0x9152760 of class UITextField was deallocated while key value observers were still registered with it. Observation info was leaked, and may even become mistakenly attached to some other object. Set a breakpoint on NSKVODeallocateBreak to stop here in the debugger. Here's the current observation info:
<NSKeyValueObservationInfo 0x91542c0> (
<NSKeyValueObservance 0x9154360: Observer: 0xc959c00, Key path: selectedTextRange, Options: <New: NO, Old: NO, Prior: NO> Context: 0x2801a8, Property: 0x10559640>
)
```

I had this view in a series of collection view cells, and when I would pop the collection view controller I was in _off_ of the navigation stack, it'd throw a warning for each one of the cells that had `RMSTokenView` in it. This PR takes care of that.

Thanks for this library; it's sure coming in handy for me — and it's incredibly well-written. Which may just be a fancy way of saying it matches my coding style to a T (hah)!

You guys are awesome for providing this.
