### PR TITLE
Adding option to remove all tokens at once.

### DIFF
--- a/RMSTokenView/RMSTokenView.h
+++ b/RMSTokenView/RMSTokenView.h
@@ -28,6 +28,7 @@
 - (void)addTokenWithText:(NSString *)tokenText;
 - (void)removeTokenWithText:(NSString *)tokenText;
 - (void)selectTokenWithText:(NSString *)tokenText;
+- (void)removeAllTokens;
 
 - (void)setSearching:(BOOL)searching animated:(BOOL)animated;
 

--- a/RMSTokenView/RMSTokenView.m
+++ b/RMSTokenView/RMSTokenView.m
@@ -229,6 +229,20 @@ NSString *RMSBackspaceUnicodeString = @"\u200B";
     }
 }
 
+- (void)removeAllTokens {
+    [self.tokenViews enumerateObjectsUsingBlock:^(UIButton *buttonToRemove, NSUInteger idx, BOOL *stop) {
+        [buttonToRemove removeFromSuperview];
+        if ([self.tokenDelegate respondsToSelector:@selector(tokenView:didRemoveTokenWithText:)]) {
+            [self.tokenDelegate tokenView:self didRemoveTokenWithText:buttonToRemove.titleLabel.text];
+        }
+    }];
+    
+    [self.tokenViews removeAllObjects];
+    
+    [self updateSummary];
+    [self resetLines];
+}
+
 - (void)updateTextField {
     self.textField.hidden = (self.selectedToken || ![self.textField isFirstResponder]);
 }


### PR DESCRIPTION
In using this library, I found it useful to add a function to remove all tokens at once. I had an instance of `RMSTokenView` in a collection view cell, and in order to provide clean reuse (in `-[UICollectionViewCell prepareForReuse]`), I wanted to a way to clear out the token views in use.

Let me know if you'd like anything else with this PR request; I'm happy to accomodate.
