### PR TITLE
fix memory leaks and remove a dead store

### DIFF
--- a/RMSTokenView/RMSTokenConstraintManager.m
+++ b/RMSTokenView/RMSTokenConstraintManager.m
@@ -30,7 +30,6 @@ RMSTokenConstraintManager *sharedManager;
     if (!heightConstraint) {
         self.heightConstraint = [NSLayoutConstraint constraintWithItem:self.tokenView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:RMSTokenLineHeight + 1];
         [self.tokenView addConstraint:self.heightConstraint];
-        heightConstraint = self.heightConstraint;
     } else {
         self.heightConstraint = heightConstraint;
     }

--- a/RMSTokenView/RMSTokenView.m
+++ b/RMSTokenView/RMSTokenView.m
@@ -583,6 +583,9 @@ NSString *RMSBackspaceUnicodeString = @"\u200B";
         CGPoint endPoint = CGPointMake(rect.size.width / 2.0, rect.size.height);
 
         CGContextDrawLinearGradient(context, gradient, startPoint, endPoint, 0);
+
+        CGGradientRelease(gradient);
+        CGColorSpaceRelease(colorSpace);
     } else {
         CGContextSetFillColorWithColor(context, topColor.CGColor);
         UIRectFill(rect);


### PR DESCRIPTION
This fixes some memory leaks on iOS 6 (when the TokenView's needsGradient property is YES), and remove a dead store from the constraint manager.
