### PR TITLE
change tokenDelegate property to weak and mark it as an IBOutlet

### DIFF
--- a/RMSTokenView/RMSTokenView.h
+++ b/RMSTokenView/RMSTokenView.h
@@ -24,7 +24,7 @@
 @property (nonatomic, strong, readonly) NSString *summary;
 @property (nonatomic, strong, readonly) NSArray *tokens; /* List of NSStrings */
 
-@property (nonatomic, strong) id<RMSTokenDelegate> tokenDelegate;
+@property (nonatomic, weak) IBOutlet id<RMSTokenDelegate> tokenDelegate;
 
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *heightConstraint;
 


### PR DESCRIPTION
I ran into a retain cycle issue when using RMSTokenView with the tokenDelegate property set.

Changing the tokenDelegate property to weak fixes the issue.

Also, I marked it with IBOutlet so the tokenDelegate can be set in Interface Builder.
