### PR TITLE
Avoid crash when multiple token fields causes a crash due to the constra...

### DIFF
--- a/RMSTokenView/RMSTokenConstraintManager.h
+++ b/RMSTokenView/RMSTokenConstraintManager.h
@@ -15,8 +15,6 @@
 @property (nonatomic, weak) UIView *tokenContentView;
 @property (nonatomic, strong) NSLayoutConstraint *heightConstraint;
 
-+ (id)manager;
-
 - (void)setupheightConstraintFromOutlet:(NSLayoutConstraint *)heightConstraint;
 - (void)setupContentViewConstraints:(UIView *)contentView;
 - (void)setupLineViewConstraints:(UIView *)lineView;

--- a/RMSTokenView/RMSTokenConstraintManager.m
+++ b/RMSTokenView/RMSTokenConstraintManager.m
@@ -18,14 +18,6 @@ RMSTokenConstraintManager *sharedManager;
 
 @implementation RMSTokenConstraintManager
 
-+ (id)manager {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedManager = [[RMSTokenConstraintManager alloc] init];
-    });
-    return sharedManager;
-}
-
 - (void)setupheightConstraintFromOutlet:(NSLayoutConstraint *)heightConstraint {
     if (!heightConstraint) {
         self.heightConstraint = [NSLayoutConstraint constraintWithItem:self.tokenView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:RMSTokenLineHeight + 1];

--- a/RMSTokenView/RMSTokenView.m
+++ b/RMSTokenView/RMSTokenView.m
@@ -64,7 +64,7 @@
     _tokenViews = [NSMutableArray array];
     _tokenLines = [NSMutableArray arrayWithObject:[NSMutableArray array]];
     
-    _constraintManager = [RMSTokenConstraintManager manager];
+    _constraintManager = [[RMSTokenConstraintManager alloc] init];
     _constraintManager.tokenView = self;
     
     [self setupViews];


### PR DESCRIPTION
...int manager's layout references to the other token field instance

Having multiple token views in the view hierarchy caused the following crash.
This pull request aims to fix this issue.

```
The view hierarchy is not prepared for the constraint: <NSLayoutConstraint:0x146f0800 H:|-(16)-[RMSTextField:0x18356970]   (Names: '|':UIView:0x183556b0 )>
	When added to a view, the constraint's items must be descendants of that view (or the view itself). This will crash if the constraint needs to be resolved before the view hierarchy is assembled. Break on -[UIView _viewHierarchyUnpreparedForConstraint:] to debug.
2014-12-11 16:32:37.118 *** Assertion failure in -[UIView _layoutEngine_didAddLayoutConstraint:roundingAdjustment:mutuallyExclusiveConstraints:], /SourceCache/UIKit/UIKit-3318.16.21/NSLayoutConstraint_UIKitAdditions.m:560
2014-12-11 16:32:37.119 ⛔ CRASH: Impossible to set up layout with view hierarchy unprepared for constraint.
2014-12-11 16:32:37.159 LOVOO[4858:2058560] 🚹 Stack Trace: (
	0   CoreFoundation                      0x23f414b7 <redacted> + 150
	1   libobjc.A.dylib                     0x316f7c8b objc_exception_throw + 38
	2   CoreFoundation                      0x23f41375 <redacted> + 0
	3   Foundation                          0x24c12d7f <redacted> + 90
	4   UIKit                               0x27a2c935 <redacted> + 172
	5   UIKit                               0x274ec4c3 <redacted> + 350
	6   UIKit                               0x274ec32f <redacted> + 34
	7   UIKit                               0x274ec2a3 <redacted> + 242
	8   UIKit                               0x27a2ca71 <redacted> + 28
	9   UIKit                               0x274f50f9 <redacted> + 132
	10  Foundation                          0x24bca5b9 <redacted> + 256
	11  UIKit                               0x274f506d <redacted> + 280
	12  LOVOO                               0x007aab21 -[RMSTokenConstraintManager updateConstraintsForTokenLines:andLineView:withTextFieldFocus:isSearching:] + 2032
	13  LOVOO                               0x007ad125 -[RMSTokenView updateConstraints] + 224
	14  UIKit                               0x27a31327 <redacted> + 222
	15  UIKit                               0x27a31513 <redacted> + 126
	16  CoreFoundation                      0x23e52e2d CFArrayApplyFunction + 36
	17  UIKit                               0x27a312cd <redacted> + 132
	18  Foundation                          0x24bca5b9 <redacted> + 256
	19  UIKit                               0x27a31513 <redacted> + 126
	20  UIKit                               0x274f02d1 <redacted> + 84
	21  Foundation                          0x24bca5b9 <redacted> + 256
	22  UIKit                               0x274f00ab <redacted> + 206
	23  UIKit                               0x27a31797 <redacted> + 162
	24  UIKit                               0x27413b1b <redacted> + 542
	25  LOVOO                               0x007adbe9 __41-[RMSTokenView textFieldDidBeginEditing:]_block_invoke + 356
	26  LOVOO                               0x004e790b __92+[UIView(AnimatedProperty) anp_new_animateWithDuration:delay:options:animations:completion:]_block_invoke + 298
	27  UIKit                               0x27434d63 <redacted> + 482
	28  UIKit                               0x2744a8fd <redacted> + 64
	29  LOVOO                               0x004e7783 +[UIView(AnimatedProperty) anp_new_animateWithDuration:delay:options:animations:completion:] + 474
	30  LOVOO                               0x007ada79 -[RMSTokenView textFieldDidBeginEditing:] + 116
	31  LOVOO                               0x006b7871 -[A2DynamicUITextFieldDelegate textFieldDidBeginEditing:] + 96
	32  UIKit                               0x274f77c9 <redacted> + 528
	33  UIKit                               0x2747c7bb <redacted> + 346
	34  UIKit                               0x2747cab7 <redacted> + 106
	35  UIKit                               0x274f62cf <redacted> + 46
	36  LOVOO                               0x007ad763 -[RMSTokenView becomeFirstResponder] + 46
	37  LOVOO                               0x005419f1 -[LVHashtagSearchViewController viewDidAppear:] + 168
	38  UIKit                               0x2741955b <redacted> + 502
	39  UIKit                               0x27419a17 <redacted> + 290
	40  UIKit                               0x2798622f <redacted> + 294
	41  UIKit                               0x279fcb07 <redacted> + 90
	42  UIKit                               0x279fd417 <redacted> + 50
	43  UIKit                               0x279f94c1 <redacted> + 32
	44  UIKit                               0x279fd8b1 <redacted> + 664
	45  UIKit                               0x279fa1dd <redacted> + 172
	46  UIKit                               0x2740124f <redacted> + 514
	47  QuartzCore                          0x26e29a0d <redacted> + 136
	48  QuartzCore                          0x26e253e5 <redacted> + 360
	49  QuartzCore                          0x26e2526d <redacted> + 16
	50  QuartzCore                          0x26e24c51 <redacted> + 224
	51  QuartzCore                          0x26e24a55 <redacted> + 324
	52  QuartzCore                          0x26e77709 <redacted> + 524
	53  IOMobileFramebuffer                 0x2b75d82b <redacted> + 90
	54  IOKit                               0x24e674e1 IODispatchCalloutFromCFMessage + 256
	55  CoreFoundation                      0x23ef70a5 <redacted> + 132
	56  CoreFoundation                      0x23f07573 <redacted> + 34
	57  CoreFoundation                      0x23f0750f <redacted> + 346
	58  CoreFoundation                      0x23f05b11 <redacted> + 1608
	59  CoreFoundation                      0x23e533c1 CFRunLoopRunSpecific + 476
	60  CoreFoundation                      0x23e531d3 CFRunLoopRunInMode + 106
	61  GraphicsServices                    0x2b2510a9 GSEventRunModal + 136
	62  UIKit                               0x27462fa1 UIApplicationMain + 1440
	63  LOVOO                               0x0003ed45 main + 48
	64  libdyld.dylib                       0x31c77aaf <redacted> + 2
)
2014-12-11 16:32:37.164 LOVOO[4858:2058560] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Impossible to set up layout with view hierarchy unprepared for constraint.'
*** First throw call stack:
(0x23f4149f 0x316f7c8b 0x23f41375 0x24c12d7f 0x27a2c935 0x274ec4c3 0x274ec32f 0x274ec2a3 0x27a2ca71 0x274f50f9 0x24bca5b9 0x274f506d 0x7aab21 0x7ad125 0x27a31327 0x27a31513 0x23e52e2d 0x27a312cd 0x24bca5b9 0x27a31513 0x274f02d1 0x24bca5b9 0x274f00ab 0x27a31797 0x27413b1b 0x7adbe9 0x4e790b 0x27434d63 0x2744a8fd 0x4e7783 0x7ada79 0x6b7871 0x274f77c9 0x2747c7bb 0x2747cab7 0x274f62cf 0x7ad763 0x5419f1 0x2741955b 0x27419a17 0x2798622f 0x279fcb07 0x279fd417 0x279f94c1 0x279fd8b1 0x279fa1dd 0x2740124f 0x26e29a0d 0x26e253e5 0x26e2526d 0x26e24c51 0x26e24a55 0x26e77709 0x2b75d82b 0x24e674e1 0x23ef70a5 0x23f07573 0x23f0750f 0x23f05b11 0x23e533c1 0x23e531d3 0x2b2510a9 0x27462fa1 0x3ed45 0x31c77aaf)
libc++abi.dylib: terminating with uncaught exception of type NSException
Signal: 6 (signal SIGABRT)
```