### PR TITLE
iOS 7: Items disappear when scroll view loses focus

### DIFF
--- a/RMSTokenView/RMSTokenConstraintManager.m
+++ b/RMSTokenView/RMSTokenConstraintManager.m
@@ -113,7 +113,7 @@ RMSTokenConstraintManager *sharedManager;
     }
 
 
-    [self.updatingConstraints addObject:[NSLayoutConstraint constraintWithItem:self.tokenContentView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:self.tokenView.contentSize.height]];
+    [self.updatingConstraints addObject:[NSLayoutConstraint constraintWithItem:self.tokenContentView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:self.heightConstraint.constant]];
     [self.updatingConstraints addObject:[NSLayoutConstraint constraintWithItem:self.tokenContentView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:self.tokenView.contentSize.width]];
 
     [self.tokenContentView addConstraints:self.updatingConstraints];

--- a/RMSTokenView/RMSTokenView.m
+++ b/RMSTokenView/RMSTokenView.m
@@ -484,7 +484,6 @@
             for (UIView *tokenView in self.tokenViews) {
                 tokenView.alpha = 0.0;
             }
-            self.textField.alpha = 0.0;
             self.summaryLabel.alpha = 1.0;
 
             [self setNeedsUpdateConstraints];


### PR DESCRIPTION
Inputting items seems fine:
![1](https://f.cloud.github.com/assets/11466/1326827/6277127e-34e5-11e3-8e6c-f2bee40799ef.png)

When the scroll view has been deselected, the names disappear:
![2](https://f.cloud.github.com/assets/11466/1326826/625b7d16-34e5-11e3-8438-2603622f72c7.png)
